### PR TITLE
Fix OpenAI key session storage

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,8 +23,9 @@ from modules.strategy_motivations_toolkit.initiatives_strategy_generator_page im
 from app_config import model
 
 
-if openai.api_key not in st.session_state:
-    openai.api_key = st.secrets["OPENAI_API_KEY"]
+if "OPENAI_API_KEY" not in st.session_state:
+    st.session_state["OPENAI_API_KEY"] = st.secrets["OPENAI_API_KEY"]
+openai.api_key = st.session_state["OPENAI_API_KEY"]
 
 # Initialise session state for page navigation
 if 'page' not in st.session_state:


### PR DESCRIPTION
## Summary
- ensure OPENAI_API_KEY is stored in Streamlit session state
- always set `openai.api_key` from session state

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6879c114e140832a91406bb78a60034c