### PR TITLE
Fix mapping heading emoji

### DIFF
--- a/modules/strategy_motivations_toolkit/strategy_capability_mapping_page.py
+++ b/modules/strategy_motivations_toolkit/strategy_capability_mapping_page.py
@@ -127,7 +127,7 @@ def strategy_capability_mapping_page():
         st.session_state['cap_columns']['text']):  # Check if list is not empty
         
         st.markdown("---")
-        st.markdown("### � Generate Mappings")
+        st.markdown("### 🚀 Generate Mappings")
         
         # Additional context input
         additional_context = st.text_area(


### PR DESCRIPTION
## Summary
- use rocket emoji in mapping page heading

## Testing
- `python -m py_compile modules/strategy_motivations_toolkit/strategy_capability_mapping_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6879c113f0b4832ab2e469fdb688e8c3