### PR TITLE
Fix OpenAI API key loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,7 +23,8 @@ from modules.strategy_motivations_toolkit.initiatives_strategy_generator_page im
 from app_config import model
 
 
-if openai.api_key not in st.session_state:
+# Ensure the OpenAI API key is configured only once
+if not openai.api_key:
     openai.api_key = st.secrets["OPENAI_API_KEY"]
 
 # Initialise session state for page navigation


### PR DESCRIPTION
## Summary
- check for missing `openai.api_key` instead of verifying membership in `st.session_state`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879bfdba2c8832aa1723ff6140b5b76