### PR TITLE
Add admin testing tool

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from modules.engagement_planning_toolkit.engagement_touchpoint_planning_page imp
 from modules.strategy_motivations_toolkit.strategy_motivations_toolkit_page import strategy_motivations_toolkit_page
 from modules.strategy_motivations_toolkit.strategy_capability_mapping_page import strategy_capability_mapping_page
 from modules.strategy_motivations_toolkit.initiatives_strategy_generator_page import initiatives_strategy_generator_page
+from modules.admin_tool_page import admin_tool_page
 from app_config import model
 
 
@@ -78,3 +79,5 @@ elif st.session_state.page == "Strategy to Capability Mapping":
     strategy_capability_mapping_page()
 elif st.session_state.page == "Tactics to Strategies Generator":
     initiatives_strategy_generator_page()
+elif st.session_state.page == "Admin Tool":
+    admin_tool_page()

--- a/modules/admin_tool_page.py
+++ b/modules/admin_tool_page.py
@@ -1,0 +1,42 @@
+import streamlit as st
+from langchain_core.messages import HumanMessage
+from app_config import model
+
+
+def admin_tool_page():
+    # Breadcrumb navigation
+    breadcrumb_container = st.container()
+    with breadcrumb_container:
+        col1, col2, col3 = st.columns([1.2, 0.2, 4])
+        with col1:
+            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
+                st.session_state.page = "Home"
+                st.rerun()
+        with col2:
+            st.markdown("**›**")
+        with col3:
+            st.markdown("**⚙️ Admin & Testing Tool**")
+
+    st.markdown("---")
+    st.markdown("## Connection Check")
+
+    # Check for OpenAI API key
+    api_key = st.secrets.get("OPENAI_API_KEY")
+    if api_key:
+        st.success("OpenAI API key detected")
+    else:
+        st.error("OpenAI API key not found in Streamlit secrets")
+
+    # Display configured model name
+    model_name = getattr(model, "model_name", "Unknown")
+    st.info(f"Configured model: **{model_name}**")
+
+    if st.button("Run connectivity test", type="primary"):
+        with st.spinner("Contacting model..."):
+            try:
+                response = model.invoke([HumanMessage(content="Hello")])
+                st.success("Model responded successfully")
+                st.write(response.content)
+            except Exception as e:
+                st.error(f"Failed to connect: {e}")
+

--- a/modules/home_page.py
+++ b/modules/home_page.py
@@ -114,5 +114,19 @@ def home_page():
         if st.button("Enter Strategy and Motivations Toolkit", key="enter_strategy_motivations_toolkit", use_container_width=True, type="primary"):
             st.session_state.page = "Strategy and Motivations Toolkit"
             st.rerun()
-    
+
+    # Admin & Testing Tool
+    st.markdown("<br>", unsafe_allow_html=True)
+    with st.container():
+        col_admin_text, col_admin_btn = st.columns([3, 1])
+
+        with col_admin_text:
+            st.markdown("### ⚙️ Admin & Testing Tool")
+            st.markdown("Check your OpenAI configuration and connectivity.")
+
+        with col_admin_btn:
+            if st.button("Open Tool", key="enter_admin_tool", use_container_width=True, type="primary"):
+                st.session_state.page = "Admin Tool"
+                st.rerun()
+
     st.markdown("---")


### PR DESCRIPTION
## Summary
- add Admin & Testing Tool page for checking OpenAI configuration
- link new tool from the home page
- route Admin Tool in main app

## Testing
- `python -m py_compile main.py modules/home_page.py modules/admin_tool_page.py`

------
https://chatgpt.com/codex/tasks/task_e_6879ca484d94832abea8008891a8e87d