### PR TITLE
Centralize routing and breadcrumb helper

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,25 +3,8 @@ import openai
 import streamlit as st
 import pandas as pd
 import math
-from modules.home_page import home_page
-from modules.pain_point_toolkit.pain_point_toolkit_page import pain_point_toolkit_page
-from modules.capability_toolkit.capability_toolkit_page import capability_toolkit_page
-from modules.capability_toolkit.capability_description_page import capability_description_page
-from modules.applications_toolkit.applications_toolkit_page import applications_toolkit_page
-from modules.pain_point_toolkit.pain_point_extraction_page import pain_point_extraction_page
-from modules.pain_point_toolkit.capability_mapping_page import capability_mapping_page
-from modules.pain_point_toolkit.theme_creation_page import theme_creation_page
-from modules.pain_point_toolkit.pain_point_impact_estimation_page import pain_point_impact_estimation_page
-from modules.applications_toolkit.application_capability_mapping_page import application_capability_mapping_page
-from modules.applications_toolkit.application_categorization_page import application_categorization_page
-from modules.applications_toolkit.individual_application_mapping_page import individual_application_mapping_page
-from modules.engagement_planning_toolkit.engagement_planning_toolkit_page import engagement_planning_toolkit_page
-from modules.engagement_planning_toolkit.engagement_touchpoint_planning_page import engagement_touchpoint_planning_page
-from modules.strategy_motivations_toolkit.strategy_motivations_toolkit_page import strategy_motivations_toolkit_page
-from modules.strategy_motivations_toolkit.strategy_capability_mapping_page import strategy_capability_mapping_page
-from modules.strategy_motivations_toolkit.initiatives_strategy_generator_page import initiatives_strategy_generator_page
-from modules.admin_tool_page import admin_tool_page
 from app_config import model
+from navigation import PAGE_ROUTES
 
 
 # Ensure the OpenAI API key is configured only once
@@ -45,39 +28,7 @@ st.markdown("""
 """, unsafe_allow_html=True)
 
 # Page routing based on session state only
-if st.session_state.page == "Home":
-    home_page()
-elif st.session_state.page == "Pain Point Toolkit":
-    pain_point_toolkit_page()
-elif st.session_state.page == "Capability Toolkit":
-    capability_toolkit_page()
-elif st.session_state.page == "Applications Toolkit":
-    applications_toolkit_page()
-elif st.session_state.page == "Engagement Planning Toolkit":
-    engagement_planning_toolkit_page()
-elif st.session_state.page == "Strategy and Motivations Toolkit":
-    strategy_motivations_toolkit_page()
-elif st.session_state.page == "Pain Point Extraction":
-    pain_point_extraction_page()
-elif st.session_state.page == "Pain Point Theme Creation":
-    theme_creation_page()
-elif st.session_state.page == "Pain Point to Capability Mapping":
-    capability_mapping_page()
-elif st.session_state.page == "Pain Point Impact Estimation":
-    pain_point_impact_estimation_page()
-elif st.session_state.page == "Application to Capability Mapping":
-    application_capability_mapping_page()
-elif st.session_state.page == "Application Categorisation":
-    application_categorization_page()
-elif st.session_state.page == "Individual Application to Capability Mapping":
-    individual_application_mapping_page()
-elif st.session_state.page == "Engagement Touchpoint Planning":
-    engagement_touchpoint_planning_page()
-elif st.session_state.page == "Capability Description Generation":
-    capability_description_page()
-elif st.session_state.page == "Strategy to Capability Mapping":
-    strategy_capability_mapping_page()
-elif st.session_state.page == "Tactics to Strategies Generator":
-    initiatives_strategy_generator_page()
-elif st.session_state.page == "Admin Tool":
-    admin_tool_page()
+route_func = PAGE_ROUTES.get(st.session_state.page)
+if route_func is None:
+    route_func = PAGE_ROUTES["Home"]
+route_func()

--- a/modules/admin_tool_page.py
+++ b/modules/admin_tool_page.py
@@ -1,23 +1,11 @@
 import streamlit as st
 from langchain_core.messages import HumanMessage
 from app_config import model
+from navigation import render_breadcrumbs
 
 
 def admin_tool_page():
-    # Breadcrumb navigation
-    breadcrumb_container = st.container()
-    with breadcrumb_container:
-        col1, col2, col3 = st.columns([1.2, 0.2, 4])
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        with col2:
-            st.markdown("**›**")
-        with col3:
-            st.markdown("**⚙️ Admin & Testing Tool**")
-
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("⚙️ Admin & Testing Tool", None)])
     st.markdown("## Connection Check")
 
     # Check for OpenAI API key

--- a/modules/applications_toolkit/application_capability_mapping_page.py
+++ b/modules/applications_toolkit/application_capability_mapping_page.py
@@ -4,34 +4,11 @@ from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model
 from prompts import APPLICATION_CAPABILITY_MAPPING_PROMPT
+from navigation import render_breadcrumbs
 
 def application_capability_mapping_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🏗️ Applications Toolkit", key="breadcrumb_toolkit", help="Go to Applications Toolkit"):
-                st.session_state.page = "Applications Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**🔗 Application to Capability Mapping**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🏗️ Applications Toolkit", "Applications Toolkit"), ("🔗 Application to Capability Mapping", None)])
     
     st.markdown("## 🔗 Application to Capability Mapping")
     st.markdown("_Map applications to business capabilities for technology landscape analysis_")

--- a/modules/applications_toolkit/application_categorization_page.py
+++ b/modules/applications_toolkit/application_categorization_page.py
@@ -4,34 +4,11 @@ import math
 from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model
+from navigation import render_breadcrumbs
 
 def application_categorization_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.5, 0.2, 3])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🏗️ Applications Toolkit", key="breadcrumb_toolkit", help="Go to Applications Toolkit"):
-                st.session_state.page = "Applications Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**📊 Application Categorisation**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🏗️ Applications Toolkit", "Applications Toolkit"), ("📊 Application Categorisation", None)])
     
     st.markdown("# 📊 Application Categorisation")
     st.markdown("**Categorise applications into Application, Technology, or Platform classifications**")

--- a/modules/applications_toolkit/applications_toolkit_page.py
+++ b/modules/applications_toolkit/applications_toolkit_page.py
@@ -1,24 +1,9 @@
 import streamlit as st
+from navigation import render_breadcrumbs
 
 def applications_toolkit_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3 = st.columns([1.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            st.markdown("**🏗️ Applications Toolkit**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🏗️ Applications Toolkit", None)])
     
     st.markdown("# 🏗️ Applications Toolkit")
 

--- a/modules/applications_toolkit/individual_application_mapping_page.py
+++ b/modules/applications_toolkit/individual_application_mapping_page.py
@@ -3,34 +3,11 @@ import pandas as pd
 from langchain_core.messages import HumanMessage
 from app_config import model
 from prompts import INDIVIDUAL_APPLICATION_MAPPING_PROMPT
+from navigation import render_breadcrumbs
 
 def individual_application_mapping_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.5, 0.2, 3.5])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🏗️ Applications Toolkit", key="breadcrumb_toolkit", help="Go to Applications Toolkit"):
-                st.session_state.page = "Applications Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**🎯 Individual Application Mapping**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🏗️ Applications Toolkit", "Applications Toolkit"), ("🎯 Individual Application Mapping", None)])
     
     st.markdown("# 🎯 Individual Application to Capability Mapping")
     st.markdown("**Map a single application to organisational capabilities**")

--- a/modules/capability_toolkit/capability_description_page.py
+++ b/modules/capability_toolkit/capability_description_page.py
@@ -3,34 +3,11 @@ import pandas as pd
 from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import capability_description_prompt, model
+from navigation import render_breadcrumbs
 
 def capability_description_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.5, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("📝 Capability Toolkit", key="breadcrumb_toolkit", help="Go to Capability Toolkit"):
-                st.session_state.page = "Capability Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**📝 Capability Description Generation**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("📝 Capability Toolkit", "Capability Toolkit"), ("📝 Capability Description Generation", None)])
     
     
     st.markdown("## Capability Description Generation")

--- a/modules/capability_toolkit/capability_toolkit_page.py
+++ b/modules/capability_toolkit/capability_toolkit_page.py
@@ -1,24 +1,9 @@
 import streamlit as st
+from navigation import render_breadcrumbs
 
 def capability_toolkit_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3 = st.columns([1.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            st.markdown("**📝 Capability Toolkit**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("📝 Capability Toolkit", None)])
     
     st.markdown("# 📝 Capability Toolkit")
 

--- a/modules/engagement_planning_toolkit/engagement_planning_toolkit_page.py
+++ b/modules/engagement_planning_toolkit/engagement_planning_toolkit_page.py
@@ -1,24 +1,9 @@
 import streamlit as st
+from navigation import render_breadcrumbs
 
 def engagement_planning_toolkit_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3 = st.columns([1.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            st.markdown("**📅 Engagement Planning Toolkit**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("📅 Engagement Planning Toolkit", None)])
     
     # Toolkit Overview
     st.markdown("# 📅 Engagement Planning Toolkit")

--- a/modules/engagement_planning_toolkit/engagement_touchpoint_planning_page.py
+++ b/modules/engagement_planning_toolkit/engagement_touchpoint_planning_page.py
@@ -4,34 +4,11 @@ from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model
 from prompts import ENGAGEMENT_TOUCHPOINT_PROMPT
+from navigation import render_breadcrumbs
 
 def engagement_touchpoint_planning_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.5, 0.2, 3])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("📅 Engagement Planning Toolkit", key="breadcrumb_toolkit", help="Go to Engagement Planning Toolkit"):
-                st.session_state.page = "Engagement Planning Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**📞 Engagement Touchpoint Planning**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("📅 Engagement Planning Toolkit", "Engagement Planning Toolkit"), ("📞 Engagement Touchpoint Planning", None)])
     
     # Under Development Banner
     st.warning("🚧 **Under Development** - This tool is currently being developed and refined. Features and functionality may change.")

--- a/modules/pain_point_toolkit/capability_mapping_page.py
+++ b/modules/pain_point_toolkit/capability_mapping_page.py
@@ -4,34 +4,11 @@ from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model
 from prompts import PAIN_POINT_CAPABILITY_MAPPING_PROMPT
+from navigation import render_breadcrumbs
 
 def capability_mapping_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.2, 0.2, 3])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🔍 Pain Point Toolkit", key="breadcrumb_toolkit", help="Go to Pain Point Toolkit"):
-                st.session_state.page = "Pain Point Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**🎯 Capability Mapping**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🔍 Pain Point Toolkit", "Pain Point Toolkit"), ("🎯 Capability Mapping", None)])
     
     st.markdown("## Pain Point to Capability Mapping")
     st.markdown("Upload pain points and capabilities spreadsheets to create ID-based mappings.")

--- a/modules/pain_point_toolkit/pain_point_extraction_page.py
+++ b/modules/pain_point_toolkit/pain_point_extraction_page.py
@@ -3,34 +3,11 @@ import pandas as pd
 from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import pain_point_extraction_prompt, model
+from navigation import render_breadcrumbs
 
 def pain_point_extraction_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.2, 0.2, 3])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🔍 Pain Point Toolkit", key="breadcrumb_toolkit", help="Go to Pain Point Toolkit"):
-                st.session_state.page = "Pain Point Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**🔍 Pain Point Extraction**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🔍 Pain Point Toolkit", "Pain Point Toolkit"), ("🔍 Pain Point Extraction", None)])
     
     st.markdown("## Pain Point extraction")
     uploaded_file = st.file_uploader("Choose a file")

--- a/modules/pain_point_toolkit/pain_point_impact_estimation_page.py
+++ b/modules/pain_point_toolkit/pain_point_impact_estimation_page.py
@@ -1,36 +1,13 @@
 import streamlit as st
 import pandas as pd
+from navigation import render_breadcrumbs
 from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model, pain_point_impact_estimation_prompt
 
 def pain_point_impact_estimation_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.2, 0.2, 3.5])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🔍 Pain Point Toolkit", key="breadcrumb_toolkit", help="Go to Pain Point Toolkit"):
-                st.session_state.page = "Pain Point Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**📊 Pain Point Impact Estimation**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🔍 Pain Point Toolkit", "Pain Point Toolkit"), ("📊 Pain Point Impact Estimation", None)])
     
     st.markdown("## 📊 Pain Point Impact Estimation")
     st.markdown("_Assess the business impact of identified pain points_")

--- a/modules/pain_point_toolkit/pain_point_toolkit_page.py
+++ b/modules/pain_point_toolkit/pain_point_toolkit_page.py
@@ -1,24 +1,9 @@
 import streamlit as st
+from navigation import render_breadcrumbs
 
 def pain_point_toolkit_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3 = st.columns([1.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            st.markdown("**🔍 Pain Point Toolkit**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🔍 Pain Point Toolkit", None)])
     
     st.markdown("# 🔍 Pain Point Toolkit")
 

--- a/modules/pain_point_toolkit/theme_creation_page.py
+++ b/modules/pain_point_toolkit/theme_creation_page.py
@@ -4,34 +4,11 @@ from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model
 from prompts import THEME_PERSPECTIVE_MAPPING_PROMPT
+from navigation import render_breadcrumbs
 
 def theme_creation_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🔍 Pain Point Toolkit", key="breadcrumb_toolkit", help="Go to Pain Point Toolkit"):
-                st.session_state.page = "Pain Point Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**🗂️ Theme & Perspective Mapping**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🔍 Pain Point Toolkit", "Pain Point Toolkit"), ("🗂️ Theme & Perspective Mapping", None)])
     
     st.markdown("## Pain Point Theme & Perspective Mapping")
     st.markdown("Upload a pain points spreadsheet to map each pain point to themes and perspectives.")

--- a/modules/strategy_motivations_toolkit/initiatives_strategy_generator_page.py
+++ b/modules/strategy_motivations_toolkit/initiatives_strategy_generator_page.py
@@ -8,33 +8,10 @@ from prompts import (
     STRATEGY_DETAILED_PROMPT,
 )
 
+from navigation import render_breadcrumbs
 def initiatives_strategy_generator_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.8, 0.2, 3.2])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🎯 Strategy and Motivations Toolkit", key="breadcrumb_toolkit", help="Go to Strategy and Motivations Toolkit"):
-                st.session_state.page = "Strategy and Motivations Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**📈 Tactics to Strategies Generator**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🎯 Strategy and Motivations Toolkit", "Strategy and Motivations Toolkit"), ("📈 Tactics to Strategies Generator", None)])
     
     st.markdown("# 📈 Tactics to Strategies Generator")
     st.markdown("**Identify strategic activities that your tactical initiatives are designed to deliver**")

--- a/modules/strategy_motivations_toolkit/strategy_capability_mapping_page.py
+++ b/modules/strategy_motivations_toolkit/strategy_capability_mapping_page.py
@@ -4,34 +4,11 @@ from io import BytesIO
 from langchain_core.messages import HumanMessage
 from app_config import model
 from prompts import STRATEGY_CAPABILITY_MAPPING_PROMPT
+from navigation import render_breadcrumbs
 
 def strategy_capability_mapping_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3, col4, col5 = st.columns([1.2, 0.2, 2.8, 0.2, 3])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            if st.button("🎯 Strategy and Motivations Toolkit", key="breadcrumb_toolkit", help="Go to Strategy and Motivations Toolkit"):
-                st.session_state.page = "Strategy and Motivations Toolkit"
-                st.rerun()
-        
-        with col4:
-            st.markdown("**›**")
-        
-        with col5:
-            st.markdown("**🎯 Strategy to Capability Mapping**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🎯 Strategy and Motivations Toolkit", "Strategy and Motivations Toolkit"), ("🎯 Strategy to Capability Mapping", None)])
     
     st.markdown("## Strategy to Capability Mapping")
     st.markdown("Upload strategic initiatives and capabilities spreadsheets to create ID-based mappings.")

--- a/modules/strategy_motivations_toolkit/strategy_motivations_toolkit_page.py
+++ b/modules/strategy_motivations_toolkit/strategy_motivations_toolkit_page.py
@@ -1,24 +1,9 @@
 import streamlit as st
+from navigation import render_breadcrumbs
 
 def strategy_motivations_toolkit_page():
     # Breadcrumb navigation as a single line with clickable elements
-    breadcrumb_container = st.container()
-    
-    with breadcrumb_container:
-        col1, col2, col3 = st.columns([1.2, 0.2, 4])
-        
-        with col1:
-            if st.button("🏠 Home", key="breadcrumb_home", help="Go to Home"):
-                st.session_state.page = "Home"
-                st.rerun()
-        
-        with col2:
-            st.markdown("**›**")
-        
-        with col3:
-            st.markdown("**🎯 Strategy and Motivations Toolkit**")
-    
-    st.markdown("---")
+    render_breadcrumbs([("🏠 Home", "Home"), ("🎯 Strategy and Motivations Toolkit", None)])
     
     # Toolkit Overview
     st.markdown("# 🎯 Strategy and Motivations Toolkit")

--- a/navigation.py
+++ b/navigation.py
@@ -1,0 +1,97 @@
+import streamlit as st
+from typing import List, Tuple, Optional, Callable
+
+# Type alias for breadcrumb items
+BreadcrumbItem = Tuple[str, Optional[str]]  # (label, target page)
+
+
+def render_breadcrumbs(items: List[BreadcrumbItem]) -> None:
+    """Render a breadcrumb navigation bar.
+
+    Parameters
+    ----------
+    items: List of tuples where each tuple contains the label to display and
+        an optional target page name. When a target page is provided, a button
+        is rendered that navigates to that page when clicked. The last item is
+        treated as the current page and should typically have ``None`` as the
+        target.
+    """
+    breadcrumb_container = st.container()
+
+    # Build column weights: slightly wider first column, arrows in between,
+    # last column a bit larger.
+    weights = []
+    for i, _ in enumerate(items):
+        if i == 0:
+            weights.append(1.2)
+        elif i == len(items) - 1 and len(items) == 2:
+            weights.append(4)
+        elif i == len(items) - 1:
+            weights.append(3)
+        else:
+            weights.append(2.2)
+        if i < len(items) - 1:
+            weights.append(0.2)
+
+    with breadcrumb_container:
+        cols = st.columns(weights)
+        for i, (label, page) in enumerate(items):
+            with cols[i * 2]:
+                if page:
+                    key = f"breadcrumb_{label.replace(' ', '_').lower()}_{i}"
+                    if st.button(label, key=key, help=f"Go to {label}"):
+                        st.session_state.page = page
+                        st.rerun()
+                else:
+                    st.markdown(f"**{label}**")
+            if i < len(items) - 1:
+                with cols[i * 2 + 1]:
+                    st.markdown("**›**")
+    st.markdown("---")
+
+
+# Mapping of page names to their corresponding functions
+PageFunc = Callable[[], None]
+PAGE_ROUTES: dict[str, PageFunc] = {}
+
+# Page modules imported below for route mapping
+from modules.home_page import home_page
+from modules.pain_point_toolkit.pain_point_toolkit_page import pain_point_toolkit_page
+from modules.capability_toolkit.capability_toolkit_page import capability_toolkit_page
+from modules.capability_toolkit.capability_description_page import capability_description_page
+from modules.applications_toolkit.applications_toolkit_page import applications_toolkit_page
+from modules.pain_point_toolkit.pain_point_extraction_page import pain_point_extraction_page
+from modules.pain_point_toolkit.capability_mapping_page import capability_mapping_page
+from modules.pain_point_toolkit.theme_creation_page import theme_creation_page
+from modules.pain_point_toolkit.pain_point_impact_estimation_page import pain_point_impact_estimation_page
+from modules.applications_toolkit.application_capability_mapping_page import application_capability_mapping_page
+from modules.applications_toolkit.application_categorization_page import application_categorization_page
+from modules.applications_toolkit.individual_application_mapping_page import individual_application_mapping_page
+from modules.engagement_planning_toolkit.engagement_planning_toolkit_page import engagement_planning_toolkit_page
+from modules.engagement_planning_toolkit.engagement_touchpoint_planning_page import engagement_touchpoint_planning_page
+from modules.strategy_motivations_toolkit.strategy_motivations_toolkit_page import strategy_motivations_toolkit_page
+from modules.strategy_motivations_toolkit.strategy_capability_mapping_page import strategy_capability_mapping_page
+from modules.strategy_motivations_toolkit.initiatives_strategy_generator_page import initiatives_strategy_generator_page
+from modules.admin_tool_page import admin_tool_page
+
+# Dictionary mapping page names to functions
+PAGE_ROUTES: dict[str, PageFunc] = {
+    "Home": home_page,
+    "Pain Point Toolkit": pain_point_toolkit_page,
+    "Capability Toolkit": capability_toolkit_page,
+    "Applications Toolkit": applications_toolkit_page,
+    "Engagement Planning Toolkit": engagement_planning_toolkit_page,
+    "Strategy and Motivations Toolkit": strategy_motivations_toolkit_page,
+    "Pain Point Extraction": pain_point_extraction_page,
+    "Pain Point Theme Creation": theme_creation_page,
+    "Pain Point to Capability Mapping": capability_mapping_page,
+    "Pain Point Impact Estimation": pain_point_impact_estimation_page,
+    "Application to Capability Mapping": application_capability_mapping_page,
+    "Application Categorisation": application_categorization_page,
+    "Individual Application to Capability Mapping": individual_application_mapping_page,
+    "Engagement Touchpoint Planning": engagement_touchpoint_planning_page,
+    "Capability Description Generation": capability_description_page,
+    "Strategy to Capability Mapping": strategy_capability_mapping_page,
+    "Tactics to Strategies Generator": initiatives_strategy_generator_page,
+    "Admin Tool": admin_tool_page,
+}


### PR DESCRIPTION
## Summary
- add `navigation.py` with breadcrumb utility and page router
- use centralized `PAGE_ROUTES` dictionary in `main.py`
- replace duplicated breadcrumb code across page modules with `render_breadcrumbs`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6879d497171c832aa2c02f9c2ab74ffa