### PR TITLE
Add API key management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,5 @@ __marimo__/
 # Streamlit
 .streamlit/
 */secrets.toml
+openai_keys.json
+

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ A comprehensive Streamlit-based application designed for management consultants 
    ```
 
 4. **Configure OpenAI API:**
-   - Create a `.streamlit/secrets.toml` file in the project root
-   - Add your OpenAI API key:
-     ```toml
-     OPENAI_API_KEY = "your-api-key-here"
+   - Create an `openai_keys.json` file in the project root with your keys:
+     ```json
+     {"active": "default", "keys": {"default": "your-api-key-here"}}
      ```
+   - You can also manage keys from the **Admin & Testing Tool** within the app or
+     provide a fallback key in `.streamlit/secrets.toml` using `OPENAI_API_KEY`.
 
 5. **Run the application:**
    ```bash
@@ -143,8 +144,9 @@ consultingToolkit/
 ├── app_config.py             # AI model configuration and prompts
 ├── requirements.txt          # Python dependencies
 ├── run.sh                   # Startup script
+├── openai_keys.json         # Stored API keys
 ├── .streamlit/
-│   └── secrets.toml         # OpenAI API configuration
+│   └── secrets.toml         # Optional fallback key
 └── modules/
     ├── home_page.py         # Landing page and toolkit overview
     ├── pain_point_toolkit/  # Pain point analysis tools

--- a/main.py
+++ b/main.py
@@ -1,31 +1,34 @@
-
 import openai
 import streamlit as st
 import pandas as pd
 import math
 from app_config import model
 from navigation import PAGE_ROUTES
+from modules.api_key_manager import get_active_key
 
 
 # Ensure the OpenAI API key is configured only once
 if not openai.api_key:
-    openai.api_key = st.secrets["OPENAI_API_KEY"]
+    openai.api_key = get_active_key() or st.secrets.get("OPENAI_API_KEY")
 
 # Initialise session state for page navigation
-if 'page' not in st.session_state:
+if "page" not in st.session_state:
     st.session_state.page = "Home"
 
 st.markdown("# Consulting Toolkit", unsafe_allow_html=False, help=None)
 
 # Hide the sidebar completely
-st.markdown("""
+st.markdown(
+    """
 <style>
     .css-1d391kg {display: none}
     .st-emotion-cache-1d391kg {display: none}
     [data-testid="stSidebar"] {display: none}
     [data-testid="collapsedControl"] {display: none}
 </style>
-""", unsafe_allow_html=True)
+""",
+    unsafe_allow_html=True,
+)
 
 # Page routing based on session state only
 route_func = PAGE_ROUTES.get(st.session_state.page)

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,8 @@
 # Pages package
+from .api_key_manager import (
+    get_active_key,
+    add_key,
+    remove_key,
+    set_active_key,
+    list_keys,
+)

--- a/modules/admin_tool_page.py
+++ b/modules/admin_tool_page.py
@@ -2,6 +2,13 @@ import streamlit as st
 from langchain_core.messages import HumanMessage
 from app_config import model
 from navigation import render_breadcrumbs
+from .api_key_manager import (
+    list_keys,
+    add_key,
+    remove_key,
+    set_active_key,
+    get_active_key,
+)
 
 
 def admin_tool_page():
@@ -28,3 +35,37 @@ def admin_tool_page():
             except Exception as e:
                 st.error(f"Failed to connect: {e}")
 
+    st.markdown("---")
+    st.markdown("## API Key Management")
+
+    keys = list_keys()
+    active = get_active_key()
+
+    if keys:
+        selected = st.radio(
+            "Available keys",
+            keys,
+            index=keys.index(active) if active in keys else 0,
+            key="key_select",
+        )
+        col1, col2 = st.columns(2)
+        with col1:
+            if st.button("Set Active", key="set_active"):
+                set_active_key(selected)
+                st.experimental_rerun()
+        with col2:
+            if st.button("Remove Key", key="remove_key"):
+                remove_key(selected)
+                st.experimental_rerun()
+    else:
+        st.info("No API keys configured.")
+
+    with st.form("add_key_form"):
+        st.markdown("### Add New Key")
+        new_name = st.text_input("Key label")
+        new_value = st.text_input("Key value", type="password")
+        submitted = st.form_submit_button("Add Key")
+        if submitted and new_name and new_value:
+            add_key(new_name, new_value)
+            st.success("Key added")
+            st.experimental_rerun()

--- a/modules/api_key_manager.py
+++ b/modules/api_key_manager.py
@@ -1,0 +1,61 @@
+import json
+import os
+from pathlib import Path
+
+CONFIG_PATH = Path("openai_keys.json")
+
+DEFAULT_DATA = {"active": None, "keys": {}}
+
+
+def _load_data() -> dict:
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH, "r") as f:
+                return json.load(f)
+        except Exception:
+            pass
+    return DEFAULT_DATA.copy()
+
+
+def _save_data(data: dict) -> None:
+    CONFIG_PATH.write_text(json.dumps(data, indent=2))
+
+
+def get_active_key() -> str | None:
+    data = _load_data()
+    active_name = data.get("active")
+    if active_name:
+        key = data["keys"].get(active_name)
+        if key:
+            return key
+    # Fallback to env or streamlit secrets if available
+    return os.getenv("OPENAI_API_KEY")
+
+
+def list_keys() -> list[str]:
+    data = _load_data()
+    return list(data["keys"].keys())
+
+
+def add_key(name: str, key: str) -> None:
+    data = _load_data()
+    data["keys"][name] = key
+    if data.get("active") is None:
+        data["active"] = name
+    _save_data(data)
+
+
+def remove_key(name: str) -> None:
+    data = _load_data()
+    if name in data["keys"]:
+        data["keys"].pop(name)
+        if data.get("active") == name:
+            data["active"] = next(iter(data["keys"]), None)
+        _save_data(data)
+
+
+def set_active_key(name: str) -> None:
+    data = _load_data()
+    if name in data["keys"]:
+        data["active"] = name
+        _save_data(data)


### PR DESCRIPTION
## Summary
- add `api_key_manager` to store and manage multiple OpenAI API keys
- integrate API key manager with app start-up
- extend Admin & Testing Tool with an interface to add, delete and activate keys
- update documentation for new key config file
- ignore `openai_keys.json` by default

## Testing
- `python -m py_compile main.py modules/admin_tool_page.py modules/api_key_manager.py modules/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_687a0b2e098c832a9326cdc1520c8021