### PR TITLE
Add packaging utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ The repository includes a `Dockerfile` and `docker-compose.yml` for running the 
 
 This script runs `git pull` to update the code and then executes `docker compose up --build`. The application will be available at [http://localhost:8501](http://localhost:8501). Ensure `OPENAI_API_KEY` is exported in your shell so Docker can forward it to the container.
 
+### Packaging for macOS and Windows
+To bundle the application as a standalone executable, install **PyInstaller** and run the provided script:
+```bash
+pip install pyinstaller
+python package.py
+```
+This will create a `dist/ConsultingToolkit` bundle - `.app` on macOS or `.exe` on Windows.
+
+
 ## 📋 Toolkit Overview
 
 The Consulting Toolkit is organised into five specialised toolkits, each addressing specific aspects of organisational analysis and strategic development:

--- a/package.py
+++ b/package.py
@@ -1,0 +1,27 @@
+import subprocess
+import sys
+import os
+
+def build():
+    target_name = "ConsultingToolkit"
+    cmd = [
+        "pyinstaller",
+        "--clean",
+        "--onefile",
+        "--name", target_name,
+        "run.py",
+    ]
+
+    if sys.platform.startswith("darwin"):
+        # macOS: create app bundle
+        cmd.extend(["--windowed"])  # hide terminal
+    elif sys.platform.startswith("win"):
+        # Windows: standard exe
+        cmd.extend(["--noconsole"])
+    subprocess.check_call(cmd)
+
+    dist_path = os.path.join("dist", target_name + (".app" if sys.platform.startswith("darwin") else ".exe"))
+    print(f"Build complete: {dist_path}")
+
+if __name__ == "__main__":
+    build()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+import streamlit.web.cli as stcli
+import sys
+
+if __name__ == "__main__":
+    sys.argv = ["streamlit", "run", "main.py"]
+    sys.exit(stcli.main())


### PR DESCRIPTION
## Summary
- add a small wrapper `run.py` so PyInstaller can launch Streamlit
- create `package.py` with cross-platform build logic
- update README with instructions for building macOS/Windows bundles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0a658f04832a802a4654d4c3e5c4